### PR TITLE
Fix script path for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,6 @@
 </head>
 <body>
   <div id="ui"></div>
-  <script type="module" src="/src/main.js"></script>
+  <script type="module" src="./src/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use relative path for module script so `/src/main.js` loads correctly when hosted under a subpath

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b470ee557c832bb1219ce2259e0a8b