### PR TITLE
fix module specifiers for pixi and deps

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,21 @@
 </head>
 <body>
   <div id="ui"></div>
+  <script type="importmap">
+  {
+    "imports": {
+      "pixi.js": "https://esm.sh/pixi.js@8.12.0",
+      "@pixi/filter-adjustment": "https://esm.sh/@pixi/filter-adjustment@5.1.1",
+      "@pixi/filter-advanced-bloom": "https://esm.sh/@pixi/filter-advanced-bloom@5.1.1",
+      "matter-js": "https://esm.sh/matter-js@0.20.0",
+      "matter-attractors": "https://esm.sh/matter-attractors@0.1.6",
+      "matter-wrap": "https://esm.sh/matter-wrap@0.2.0",
+      "howler": "https://esm.sh/howler@2.2.4",
+      "tone": "https://esm.sh/tone@15.1.22",
+      "behavior3js": "https://esm.sh/behavior3js@0.2.2"
+    }
+  }
+  </script>
   <script type="module" src="./src/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use import map to resolve `pixi.js` and other dependencies from `esm.sh`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b472436138832b8d8da808d96e82cd