### PR TITLE
chore: remove matter.js plugins causing runtime errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Minimal vertical slice for a mobile-friendly 2D ambient god-sandbox.
 
 ## Stack
 - [PixiJS](https://github.com/pixijs/pixijs) for rendering.
-- [Matter.js](https://github.com/liabru/matter-js) with [matter-attractors](https://github.com/liabru/matter-attractors) and [matter-wrap](https://github.com/liabru/matter-wrap).
+- [Matter.js](https://github.com/liabru/matter-js) for physics.
 - [Behavior3JS](https://github.com/behavior3/behavior3js) for agent logic.
 - [pixijs/filters](https://github.com/pixijs/filters) for subtle bloom/adjustment.
 - [Howler.js](https://github.com/goldfire/howler.js) and [Tone.js](https://github.com/Tonejs/Tone.js) for audio.

--- a/index.html
+++ b/index.html
@@ -19,8 +19,6 @@
       "@pixi/filter-adjustment": "https://esm.sh/@pixi/filter-adjustment@5.1.1",
       "@pixi/filter-advanced-bloom": "https://esm.sh/@pixi/filter-advanced-bloom@5.1.1",
       "matter-js": "https://esm.sh/matter-js@0.20.0",
-      "matter-attractors": "https://esm.sh/matter-attractors@0.1.6",
-      "matter-wrap": "https://esm.sh/matter-wrap@0.2.0",
       "howler": "https://esm.sh/howler@2.2.4",
       "tone": "https://esm.sh/tone@15.1.22",
       "behavior3js": "https://esm.sh/behavior3js@0.2.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,7 @@
         "@pixi/lights": "4.1.0",
         "behavior3js": "0.2.2",
         "howler": "2.2.4",
-        "matter-attractors": "0.1.6",
         "matter-js": "0.20.0",
-        "matter-wrap": "0.2.0",
         "pathfinding": "0.4.18",
         "pixi.js": "8.12.0",
         "seedrandom": "3.0.5",
@@ -1323,22 +1321,10 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/matter-attractors": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/matter-attractors/-/matter-attractors-0.1.6.tgz",
-      "integrity": "sha512-vGFsFHS9m0hXnaswfKXT2nKfPXJs4lwnQJwkGrs1IHrVldKAmlBKBb4OcYh0rwQga3CFWGUq3JvKpWZvZuqlDQ==",
-      "license": "MIT"
-    },
     "node_modules/matter-js": {
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/matter-js/-/matter-js-0.20.0.tgz",
       "integrity": "sha512-iC9fYR7zVT3HppNnsFsp9XOoQdQN2tUyfaKg4CHLH8bN+j6GT4Gw7IH2rP0tflAebrHFw730RR3DkVSZRX8hwA==",
-      "license": "MIT"
-    },
-    "node_modules/matter-wrap": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/matter-wrap/-/matter-wrap-0.2.0.tgz",
-      "integrity": "sha512-Gp3tETlN6uZftc1Jnv1sogQd8uB2Xh4c5bQ18qKR6KOMfUlsS8vztrC1vDrZS8eg4MuwE1AgZEcwxI41BSW6oQ==",
       "license": "MIT"
     },
     "node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -10,20 +10,18 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "pixi.js": "8.12.0",
     "@pixi/filter-adjustment": "5.1.1",
     "@pixi/filter-advanced-bloom": "5.1.1",
     "@pixi/filter-godray": "5.1.1",
     "@pixi/layers": "2.1.0",
     "@pixi/lights": "4.1.0",
-    "matter-js": "0.20.0",
-    "matter-attractors": "0.1.6",
-    "matter-wrap": "0.2.0",
     "behavior3js": "0.2.2",
     "howler": "2.2.4",
-    "tone": "15.1.22",
+    "matter-js": "0.20.0",
     "pathfinding": "0.4.18",
-    "seedrandom": "3.0.5"
+    "pixi.js": "8.12.0",
+    "seedrandom": "3.0.5",
+    "tone": "15.1.22"
   },
   "devDependencies": {
     "vite": "7.1.3"

--- a/src/physics/index.js
+++ b/src/physics/index.js
@@ -1,10 +1,5 @@
 import Matter from 'matter-js';
-import attractors from 'matter-attractors';
-import wrap from 'matter-wrap';
 import { Graphics } from 'pixi.js';
-
-Matter.use(attractors);
-Matter.use(wrap);
 
 export function initPhysics(app) {
   const engine = Matter.Engine.create();


### PR DESCRIPTION
## Summary
- drop matter-attractors and matter-wrap plugins from physics setup
- prune matching imports, docs, and dependencies

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4759b9b3c832bb6a9bc68be20cc35