### PR TITLE
Start game automatically on load

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,6 @@
   size <input id="size" type="range" min="1" max="10" value="4">
 </div>
 <div id="diag"></div>
-<button id="tapstart" aria-label="Start">Tap to start</button>
 
 <script defer src="https://cdn.jsdelivr.net/npm/excalibur@0.29.0/dist/excalibur.min.js"></script>
 <script defer src="https://cdn.jsdelivr.net/npm/tone@14.7.77/build/Tone.min.js"></script>

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,6 @@ document.addEventListener('DOMContentLoaded',()=>{
  const diag=document.getElementById('diag');
  const ca=document.getElementById('ca');
  const game=document.getElementById('game');
- const tap=document.getElementById('tapstart');
  function error(msg){const d=document.createElement('div');d.textContent=msg;d.style.color='red';d.style.fontFamily='monospace';diag.appendChild(d);}
  if(!window.ex){error('Excalibur missing');return;}
  if(!ca||!game||ca.width!==512||ca.height!==288||game.width!==512||game.height!==288){error('Missing engine or canvases');return;}
@@ -13,10 +12,9 @@ document.addEventListener('DOMContentLoaded',()=>{
    const urls=JSON.stringify(man);
    if(urls.indexOf('"http:')>-1){error('Mixed content');return;}
   }
-  tap.addEventListener('pointerdown',()=>start(man),{once:true});
+  start(man);
  }).catch(()=>error('Manifest load failed'));
  function start(man){
-  tap.style.display='none';
   Tone.start();
   initAudio(man.audio);
   initCA(ca,512,288);

--- a/styles.css
+++ b/styles.css
@@ -4,4 +4,3 @@ html,body{height:100%;margin:0;background:#222;color:#fff;font-family:sans-serif
 #game{z-index:1;}
 #ui{position:fixed;bottom:10px;left:50%;transform:translateX(-50%);background:rgba(255,255,255,0.8);padding:4px;color:#000;}
 #diag{position:fixed;top:0;left:0;font:12px monospace;color:#0f0;background:rgba(0,0,0,0.5);padding:2px 4px;pointer-events:none;}
-#tapstart{position:fixed;top:0;left:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.9);color:#fff;font-size:1.5em;border:0;}


### PR DESCRIPTION
## Summary
- auto start game when manifest loads instead of waiting for tap
- remove unused tap-to-start button and styles

## Testing
- `npm test`
- `npm run test:assets` *(fails: connect ENETUNREACH 76.176.14.35:443)*

------
https://chatgpt.com/codex/tasks/task_e_68b511011998832b8cef0e58c9444fb5