### PR TITLE
fix: replace insecure image links

### DIFF
--- a/assets/site.webmanifest
+++ b/assets/site.webmanifest
@@ -8,7 +8,7 @@
   "theme_color": "#111111",
   "icons": [
     {
-      "src": "http://killinger.synology.me/images/Test_Image.png",
+      "src": "https://killinger.synology.me/images/Test_Image.png",
       "sizes": "144x144",
       "type": "image/png"
     }

--- a/index.html
+++ b/index.html
@@ -19,11 +19,11 @@
     <link
       rel="icon"
       type="image/png"
-      href="http://killinger.synology.me/images/Test_Image.png"
+      href="https://killinger.synology.me/images/Test_Image.png"
     />
     <link
       rel="apple-touch-icon"
-      href="http://killinger.synology.me/images/Test_Image.png"
+      href="https://killinger.synology.me/images/Test_Image.png"
     />
     <link rel="manifest" href="./assets/site.webmanifest" />
     <link


### PR DESCRIPTION
## Summary
- use https instead of http for site icons to avoid mixed-content

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: sh: 1: webpack: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e5107844832ba7558bf2dd908e2b