### PR TITLE
Fix asset manifest loading and include config in build

### DIFF
--- a/config/assets.manifest.json
+++ b/config/assets.manifest.json
@@ -1,0 +1,6 @@
+{
+  "images": {
+    "logo": "./assets/SSStudio ColorLined Big.svg"
+  },
+  "audio": {}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,7 @@ module.exports = {
       "styles.css",
       "manifest.json",
       "assets/*",
+      "config/*",
     ]),
     new HtmlWebpackPlugin({ template: "index.html" }),
     new GenerateSW({


### PR DESCRIPTION
## Summary
- add a config directory with an `assets.manifest.json` file so the game can load image/audio definitions
- ensure the manifest is copied during Webpack builds

## Testing
- `npm test`
- `node -p "require('./config/assets.manifest.json')"`


------
https://chatgpt.com/codex/tasks/task_e_68b6224f22dc832bb4de92179d176d9b