### PR TITLE
feat: add simple sand simulation and palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,6 @@
   </head>
 
     <body>
-      <div id="diag">Diagnostics: ticks=0 fps=0</div>
       <canvas id="ca"></canvas>
       <div id="game"></div>
       <script type="module" src="./src/main.js"></script>

--- a/src/ca.js
+++ b/src/ca.js
@@ -1,7 +1,26 @@
+// Simple cellular automata for a falling sand style demo.
+// This is **not** a full recreation of sandspiel's complex
+// simulation, but it provides a lightweight approximation that
+// lets the page look and behave similarly to the original site.
+
 let ctx;
 let width = 0;
 let height = 0;
 let ticks = 0;
+
+// cell types
+const EMPTY = 0;
+const SAND = 1;
+const WATER = 2;
+
+// colour lookup for each cell type
+const colours = {
+  [EMPTY]: [0, 0, 0, 0],
+  [SAND]: [194, 178, 128, 255],
+  [WATER]: [64, 164, 223, 255],
+};
+
+let cells;
 
 export function initCA(canvas, w, h) {
   if (!canvas) return;
@@ -10,21 +29,87 @@ export function initCA(canvas, w, h) {
   canvas.width = w;
   canvas.height = h;
   ctx = canvas.getContext('2d');
-  ctx.fillStyle = 'black';
-  ctx.fillRect(0, 0, w, h);
+  cells = new Uint8Array(w * h);
+  drawCA();
+}
+
+function swap(i1, i2) {
+  const tmp = cells[i1];
+  cells[i1] = cells[i2];
+  cells[i2] = tmp;
 }
 
 export function stepCA() {
+  if (!cells) return;
   ticks++;
+  // update from bottom to top so particles fall correctly
+  for (let y = height - 2; y >= 0; y--) {
+    for (let x = 0; x < width; x++) {
+      const i = y * width + x;
+      const cell = cells[i];
+      if (cell === SAND) {
+        const below = i + width;
+        if (cells[below] === EMPTY) {
+          swap(i, below);
+        } else {
+          const dir = Math.random() < 0.5 ? -1 : 1;
+          const nx = x + dir;
+          const ni = below + dir;
+          if (nx >= 0 && nx < width && cells[ni] === EMPTY) {
+            swap(i, ni);
+          }
+        }
+      } else if (cell === WATER) {
+        const below = i + width;
+        if (cells[below] === EMPTY) {
+          swap(i, below);
+        } else {
+          const dirs = [-1, 1];
+          if (Math.random() < 0.5) dirs.reverse();
+          for (const dir of dirs) {
+            const nx = x + dir;
+            const ni = i + dir;
+            const bi = below + dir;
+            if (nx >= 0 && nx < width && cells[bi] === EMPTY) {
+              swap(i, bi);
+              break;
+            } else if (nx >= 0 && nx < width && cells[ni] === EMPTY) {
+              swap(i, ni);
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+  drawCA();
 }
 
 export function drawCA() {
-  if (!ctx) return;
-  const c = ticks % 255;
-  ctx.fillStyle = `rgb(${c}, ${c}, ${c})`;
-  ctx.fillRect(0, 0, width, height);
+  if (!ctx || !cells) return;
+  const img = ctx.createImageData(width, height);
+  for (let i = 0; i < cells.length; i++) {
+    const type = cells[i];
+    const colour = colours[type];
+    const off = i * 4;
+    img.data[off] = colour[0];
+    img.data[off + 1] = colour[1];
+    img.data[off + 2] = colour[2];
+    img.data[off + 3] = colour[3];
+  }
+  ctx.putImageData(img, 0, 0);
 }
 
 export function getTicks() {
   return ticks;
 }
+
+// Helper used by game.js to set cells when the user paints.
+export function setCell(x, y, type) {
+  if (!cells) return;
+  if (x < 0 || x >= width || y < 0 || y >= height) return;
+  cells[y * width + x] = type;
+}
+
+export const CellType = { EMPTY, SAND, WATER };
+

--- a/src/game.js
+++ b/src/game.js
@@ -1,9 +1,54 @@
-let gameEl;
+import { setCell, CellType } from './ca.js';
 
-export function initGame(el) {
-  gameEl = el;
+let current = CellType.SAND;
+
+// create UI buttons for selecting the active element
+function makeButton(name, type) {
+  const btn = document.createElement('button');
+  btn.textContent = name;
+  btn.addEventListener('click', () => {
+    current = type;
+    document.querySelectorAll('#palette button').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+  });
+  if (type === current) btn.classList.add('active');
+  return btn;
+}
+
+export function initGame(container) {
+  // palette on the right similar to sandspiel
+  const palette = document.createElement('div');
+  palette.id = 'palette';
+  palette.appendChild(makeButton('Sand', CellType.SAND));
+  palette.appendChild(makeButton('Water', CellType.WATER));
+  palette.appendChild(makeButton('Erase', CellType.EMPTY));
+  container.appendChild(palette);
+
+  const canvas = document.getElementById('ca');
+  if (!canvas) return;
+  let drawing = false;
+
+  function draw(e) {
+    if (!drawing) return;
+    const rect = canvas.getBoundingClientRect();
+    const x = Math.floor((e.clientX - rect.left) * (canvas.width / rect.width));
+    const y = Math.floor((e.clientY - rect.top) * (canvas.height / rect.height));
+    const size = 4; // simple brush size
+    for (let dy = -size; dy <= size; dy++) {
+      for (let dx = -size; dx <= size; dx++) {
+        if (dx * dx + dy * dy <= size * size) {
+          setCell(x + dx, y + dy, current);
+        }
+      }
+    }
+  }
+
+  canvas.addEventListener('mousedown', e => { drawing = true; draw(e); });
+  canvas.addEventListener('mousemove', draw);
+  window.addEventListener('mouseup', () => { drawing = false; });
 }
 
 export function updateGame() {
-  // placeholder for game logic
+  // no-op for now
 }
+

--- a/styles.css
+++ b/styles.css
@@ -19,7 +19,7 @@ body,
   width: 100%;
   height: calc(100% - 2px);
   /* background-color: rgba(00, 00, 00, 0.2); */
-  background-color: #f3f3f4;
+  background-color: #f4d9d8; /* soft pink like sandspiel */
 }
 
 #diag {
@@ -489,4 +489,19 @@ img {
 }
 .reversed {
   transform: rotate(180deg);
+}
+
+/* Palette used by the minimal demo in this kata */
+#palette {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  z-index: 2;
+}
+
+#palette button {
+  width: 80px;
 }


### PR DESCRIPTION
## Summary
- replace placeholder CA with basic sand & water simulation
- add palette UI for selecting elements and painting on the canvas
- style page with sandspiel-like background and layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6281821bc832baa2a21276ed98324