### PR TITLE
Enable material painting with brush size options

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -1,6 +1,7 @@
 import { setCell, CellType } from './ca.js';
 
 let current = CellType.SAND;
+let brushSize = 4;
 
 // create UI buttons for selecting the active element
 function makeButton(name, type) {
@@ -15,6 +16,18 @@ function makeButton(name, type) {
   return btn;
 }
 
+function makeBrushButton(name, size) {
+  const btn = document.createElement('button');
+  btn.textContent = name;
+  btn.addEventListener('click', () => {
+    brushSize = size;
+    document.querySelectorAll('#brushes button').forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+  });
+  if (size === brushSize) btn.classList.add('active');
+  return btn;
+}
+
 export function initGame(container) {
   // palette on the right similar to sandspiel
   const palette = document.createElement('div');
@@ -22,6 +35,14 @@ export function initGame(container) {
   palette.appendChild(makeButton('Sand', CellType.SAND));
   palette.appendChild(makeButton('Water', CellType.WATER));
   palette.appendChild(makeButton('Erase', CellType.EMPTY));
+
+  const brushes = document.createElement('div');
+  brushes.id = 'brushes';
+  brushes.appendChild(makeBrushButton('Small', 2));
+  brushes.appendChild(makeBrushButton('Medium', 4));
+  brushes.appendChild(makeBrushButton('Large', 8));
+  palette.appendChild(brushes);
+
   container.appendChild(palette);
 
   const canvas = document.getElementById('ca');
@@ -33,7 +54,7 @@ export function initGame(container) {
     const rect = canvas.getBoundingClientRect();
     const x = Math.floor((e.clientX - rect.left) * (canvas.width / rect.width));
     const y = Math.floor((e.clientY - rect.top) * (canvas.height / rect.height));
-    const size = 4; // simple brush size
+    const size = brushSize;
     for (let dy = -size; dy <= size; dy++) {
       for (let dx = -size; dx <= size; dx++) {
         if (dx * dx + dy * dy <= size * size) {
@@ -46,6 +67,18 @@ export function initGame(container) {
   canvas.addEventListener('mousedown', e => { drawing = true; draw(e); });
   canvas.addEventListener('mousemove', draw);
   window.addEventListener('mouseup', () => { drawing = false; });
+
+  canvas.addEventListener('touchstart', e => {
+    drawing = true;
+    e.preventDefault();
+    draw(e.touches[0]);
+  });
+  canvas.addEventListener('touchmove', e => {
+    if (!drawing) return;
+    e.preventDefault();
+    draw(e.touches[0]);
+  });
+  window.addEventListener('touchend', () => { drawing = false; });
 }
 
 export function updateGame() {

--- a/src/main.js
+++ b/src/main.js
@@ -33,7 +33,12 @@ window.addEventListener('DOMContentLoaded', async () => {
     if (diag) { diag.style.color = 'red'; diag.textContent = 'Error: missing #ca or #game'; }
     return;
   }
-  initCA(ca, 512, 288);
+  function resize() {
+    initCA(ca, window.innerWidth, window.innerHeight);
+  }
+
+  resize();
+  window.addEventListener('resize', resize);
   initGame(game);
   requestAnimationFrame(frame);
 

--- a/styles.css
+++ b/styles.css
@@ -34,15 +34,14 @@ body,
 
 canvas {
   position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
   bottom: 0;
-  /* top: 0; */
-  right: 0px;
-  left: 0px;
   z-index: 1;
-  max-width: calc(100% - 3px);
-  /* width: calc(100% - 0px); */
-  /* max-width: ca100%; */
-  margin: auto;
+  width: 100vw;
+  height: 100vh;
+  margin: 0;
   box-shadow: 0px 0px 3px 3px rgba(0, 0, 0, 0.1);
 }
 
@@ -504,4 +503,11 @@ img {
 
 #palette button {
   width: 80px;
+}
+
+#brushes {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }


### PR DESCRIPTION
## Summary
- Fill canvas to entire viewport and remove bottom box
- Add brush size controls and touch/mouse drawing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b62b2bd63c832b83fae29b8ae3fb6c