### PR TITLE
Fix water spreading and brush icons

### DIFF
--- a/src/ca.js
+++ b/src/ca.js
@@ -91,12 +91,13 @@ export function stepCA(dt = 16) {
             velocities[i] = 0;
           }
         } else if (cell === WATER) {
-          if (cells[below] === WATER) {
-            const splashPos = i - width + (Math.random() < 0.5 ? -1 : 1);
-            if (splashPos >= 0 && splashPos < cells.length && cells[splashPos] === EMPTY) {
-              cells[splashPos] = WATER;
-            }
-          }
+          // Water should conserve mass and flow naturally. The previous
+          // implementation spawned extra "splash" particles above bodies of
+          // water, which caused it to rapidly fill the entire simulation. By
+          // removing that behaviour and only allowing movement into empty
+          // neighbouring cells, water now falls under gravity and pools
+          // realistically.
+
           const dir = Math.random() < 0.5 ? -1 : 1;
           for (let step = 1; step <= 3; step++) {
             const nx = x + dir * step;

--- a/styles.css
+++ b/styles.css
@@ -511,6 +511,7 @@ img {
   left: 50%;
   transform: translateX(-50%);
   display: flex;
+  align-items: center;
   gap: 8px;
   z-index: 2;
 }


### PR DESCRIPTION
## Summary
- prevent water cells from duplicating by removing splash spawning and letting water flow into empty spaces
- ensure brush size buttons render as circles

## Testing
- `npm test`
- `npm run build` *(fails: dependency getrandom unspecified and node crypto error)*

------
https://chatgpt.com/codex/tasks/task_e_68b63ba6d3e0832b84dd7977f38f2c9d