### PR TITLE
Reduce canvas resolution for memory efficiency

### DIFF
--- a/src/ca.js
+++ b/src/ca.js
@@ -23,6 +23,7 @@ const colours = {
 let cells;
 let velocities;
 let waterDirs;
+let imgData;
 const GRAVITY = 0.5;
 const MAX_VEL = 5;
 
@@ -36,6 +37,7 @@ export function initCA(canvas, w, h) {
   cells = new Uint8Array(w * h);
   velocities = new Float32Array(w * h);
   waterDirs = new Int8Array(w * h);
+  imgData = ctx.createImageData(w, h);
   drawCA();
 }
 
@@ -164,18 +166,18 @@ export function stepCA(dt = 16) {
 }
 
 export function drawCA() {
-  if (!ctx || !cells) return;
-  const img = ctx.createImageData(width, height);
+  if (!ctx || !cells || !imgData) return;
+  const data = imgData.data;
   for (let i = 0; i < cells.length; i++) {
     const type = cells[i];
     const colour = colours[type];
     const off = i * 4;
-    img.data[off] = colour[0];
-    img.data[off + 1] = colour[1];
-    img.data[off + 2] = colour[2];
-    img.data[off + 3] = colour[3];
+    data[off] = colour[0];
+    data[off + 1] = colour[1];
+    data[off + 2] = colour[2];
+    data[off + 3] = colour[3];
   }
-  ctx.putImageData(img, 0, 0);
+  ctx.putImageData(imgData, 0, 0);
 }
 
 export function getTicks() {

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,10 @@ import { initCA, stepCA, getTicks } from './ca.js';
 import { initGame } from './game.js';
 import { initAudio } from './audio.js';
 
+// Size in screen pixels of each simulation pixel. Larger values lower
+// the internal resolution and reduce memory usage.
+const PIXEL_SIZE = 4;
+
 async function loadManifest() {
   try {
     const res = await fetch('./config/assets.manifest.json', { cache: 'no-cache' });
@@ -34,7 +38,11 @@ window.addEventListener('DOMContentLoaded', async () => {
     return;
   }
   function resize() {
-    initCA(ca, window.innerWidth, window.innerHeight);
+    const w = Math.floor(window.innerWidth / PIXEL_SIZE);
+    const h = Math.floor(window.innerHeight / PIXEL_SIZE);
+    ca.style.width = `${window.innerWidth}px`;
+    ca.style.height = `${window.innerHeight}px`;
+    initCA(ca, w, h);
   }
 
   resize();


### PR DESCRIPTION
## Summary
- Lower simulation resolution by introducing a pixel scaling factor and resizing logic
- Reuse preallocated ImageData buffer for drawing to avoid per-frame allocations

## Testing
- `npm test`
- `npm run build` *(fails: Error: error:0308010C:digital envelope routines::unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f7b497a8832b981c4ceb9cead95a