### PR TITLE
Enlarge menu controls and add brush size toggle

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -2,6 +2,8 @@ import { setCell, CellType } from './ca.js';
 
 let current = CellType.SAND;
 let brushSize = 4;
+const brushSizes = [2, 4, 8];
+let brushIndex = brushSizes.indexOf(brushSize);
 
 // create UI buttons for selecting the active element
 function makeButton(name, type) {
@@ -16,18 +18,24 @@ function makeButton(name, type) {
   return btn;
 }
 
-function makeBrushButton(size) {
+function makeBrushToggle() {
   const btn = document.createElement('button');
-  const d = size * 4;
-  btn.style.width = `${d}px`;
-  btn.style.height = `${d}px`;
   btn.style.borderRadius = '50%';
-  btn.addEventListener('click', () => {
+
+  function applySize() {
+    const size = brushSizes[brushIndex];
     brushSize = size;
-    document.querySelectorAll('#brushes button').forEach(b => b.classList.remove('active'));
-    btn.classList.add('active');
+    const d = size * 8; // doubled visual size
+    btn.style.width = `${d}px`;
+    btn.style.height = `${d}px`;
+  }
+
+  btn.addEventListener('click', () => {
+    brushIndex = (brushIndex + 1) % brushSizes.length;
+    applySize();
   });
-  if (size === brushSize) btn.classList.add('active');
+
+  applySize();
   return btn;
 }
 
@@ -41,9 +49,7 @@ export function initGame(container) {
 
   const brushes = document.createElement('div');
   brushes.id = 'brushes';
-  brushes.appendChild(makeBrushButton(2));
-  brushes.appendChild(makeBrushButton(4));
-  brushes.appendChild(makeBrushButton(8));
+  brushes.appendChild(makeBrushToggle());
 
   container.appendChild(brushes);
   container.appendChild(palette);

--- a/styles.css
+++ b/styles.css
@@ -502,7 +502,8 @@ img {
 }
 
 #palette button {
-  width: 80px;
+  width: 160px;
+  height: 48px;
 }
 
 #brushes {


### PR DESCRIPTION
## Summary
- Double the size of palette buttons for easier tapping
- Replace brush size slider with single round button that toggles between small, medium, and large
- Keep brush strokes circular while enlarging button visuals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4f8fccf3c832b83769bba7d50cc37