### PR TITLE
Add simulation backbone and developer tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Terrarium is the foundational codebase for a browser-based 16-bit pixel art simu
 ## Features
 
 - ⚙️ **Phaser 3 engine** configured for pixel-perfect rendering (320×240 internal resolution, nearest-neighbor scaling).
-- 🧱 **Modular scene architecture** with boot, preload, and play phases plus a toggleable debug overlay.
-- 🗂️ **Core services** for assets, storage, event messaging, and timekeeping.
+- 🧱 **Modular scene architecture** with boot, preload, and play phases plus a species-agnostic simulation spine.
+- 🕹️ **ECS-lite simulation loop** with deterministic fixed-step timing, system registry, and developer profiling hooks.
+- 🗂️ **Core services** for assets, manifests, storage (with world save slots), event messaging, and timekeeping.
 - 🧪 **Quality tooling** including ESLint, Prettier, TypeScript strict mode, and Vitest unit tests.
 - 🚀 **Vite build + GitHub Pages deployment** with CI workflows for linting, tests, type checking, and builds.
 
@@ -17,7 +18,7 @@ npm install
 npm run dev
 ```
 
-Visit the URL printed in the terminal. You should see the Phaser canvas with a pixel-perfect placeholder sprite and the debug overlay instructions.
+Visit the URL printed in the terminal. You should see the Phaser canvas with a pixel-perfect placeholder sprite and simulation status text.
 
 ### Available Scripts
 
@@ -62,9 +63,15 @@ terrarium/
 └── README.md                # Project overview (this file)
 ```
 
-## Debug Overlay
+## Developer Panel
 
-Press the **D** key while the game is running to toggle the debug overlay. It displays frame timing information sourced from the core `Time` service and provides placeholders for future diagnostics.
+While running `npm run dev` you can press the backtick key (**`**) to toggle the developer panel. The panel surfaces the simulation tick counter, elapsed simulation time, and per-system profiling data. It also exposes **Pause**, **Play**, **Step**, and **Reset** controls wired into the deterministic fixed-step clock.
+
+The panel and keyboard shortcut are available in development builds only.
+
+## World State Persistence
+
+The `StorageService` exposes `saveWorld(state)`, `loadWorld()`, and `clearWorld()` helpers that serialize deterministic ECS component snapshots. Save files follow the `WORLD_STATE_VERSION` marker defined in `src/core/sim/WorldState.ts` so future changes can be migrated in place. Version `0.1.0` represents the initial save format used in this scaffold.
 
 ## Continuous Integration & Deployment
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,265 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "phaser": "^3.70.0"
+        "phaser": "^3.70.0",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/node": "^20.11.17",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
+        "@vitest/coverage-v8": "^1.2.2",
         "eslint": "8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
+        "jsdom": "^27.0.0",
         "prettier": "^3.2.5",
         "typescript": "5.3.3",
         "vite": "^5.1.0",
         "vitest": "^1.2.2"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.0.4.tgz",
+      "integrity": "sha512-cKjSKvWGmAziQWbCouOsFwb14mp1betm8Y7Fn+yglDMUUu3r9DCbJ9iJbeFDenLMqFbIMC0pQP8K+B8LAxX3OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.0.10",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.1.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.5.5.tgz",
+      "integrity": "sha512-kI2MX9pmImjxWT8nxDZY+MuN6r1jJGe7WxizEbsAEPB/zxfW5wYLIiPG1v3UKgEOOP8EsDkp0ZL99oRFAdPM8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.14.tgz",
+      "integrity": "sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -564,6 +810,16 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -577,12 +833,44 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -957,6 +1245,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1186,6 +1481,34 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-1.2.2.tgz",
+      "integrity": "sha512-IHyKnDz18SFclIEEAHb9Y4Uxx0sPKC2VO1kdDCs1BF6Ip4S8rQprs971zIsooLUn7Afs71GRxWMWpkCGZpRMhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.1",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.4",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^4.0.1",
+        "istanbul-reports": "^3.1.6",
+        "magic-string": "^0.30.5",
+        "magicast": "^0.3.3",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "test-exclude": "^6.0.0",
+        "v8-to-istanbul": "^9.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "^1.0.0"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
@@ -1325,6 +1648,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1401,6 +1734,16 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -1528,6 +1871,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1541,6 +1891,49 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.1.tgz",
+      "integrity": "sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.0.3",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.14",
+        "css-tree": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+      "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/debug": {
@@ -1560,6 +1953,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "4.1.4",
@@ -1615,6 +2015,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/esbuild": {
@@ -2219,6 +2632,54 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -2227,6 +2688,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -2328,6 +2802,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -2348,6 +2829,60 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -2366,6 +2901,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
+      "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.5.4",
+        "cssstyle": "^5.3.0",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^7.3.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0",
+        "ws": "^8.18.2",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -2463,6 +3038,16 @@
         "get-func-name": "^2.0.1"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
+      "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.19",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
@@ -2472,6 +3057,41 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -2702,6 +3322,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -2943,6 +3576,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3023,6 +3666,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3045,6 +3695,26 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -3111,6 +3781,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -3202,6 +3882,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/synckit": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
@@ -3216,6 +3903,45 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/text-table": {
@@ -3252,6 +3978,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.15.tgz",
+      "integrity": "sha512-heYRCiGLhtI+U/D0V8YM3QRwPfsLJiP+HX+YwiHZTnWzjIKC+ZCxQRYlzvOoTEc6KIP62B1VeAN63diGCng2hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.15"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.15.tgz",
+      "integrity": "sha512-YBkp2VfS9VTRMPNL2PA6PMESmxV1JEVoAr5iBlZnB5JG3KUrWzNCB3yNNkRa2FZkqClaBgfNYCp8PgpYmpjkZw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3263,6 +4009,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3350,6 +4122,21 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
       }
     },
     "node_modules/vite": {
@@ -3501,6 +4288,66 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+      "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3551,6 +4398,45 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -3562,6 +4448,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,15 +25,18 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "phaser": "^3.70.0"
+    "phaser": "^3.70.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^20.11.17",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
+    "@vitest/coverage-v8": "^1.2.2",
     "eslint": "8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
+    "jsdom": "^27.0.0",
     "prettier": "^3.2.5",
     "typescript": "5.3.3",
     "vite": "^5.1.0",

--- a/src/core/config/schemas.ts
+++ b/src/core/config/schemas.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+export const AssetRefSchema = z
+  .object({
+    atlas: z.string().optional(),
+    frame: z.union([z.string(), z.number()]).optional(),
+    path: z.string().optional(),
+  })
+  .refine((value) => Boolean(value.atlas || value.path), {
+    message: 'Asset reference requires an atlas key or file path.',
+  });
+
+export const ProcessSchema = z.object({
+  inputs: z.record(z.string().min(1), z.number().nonnegative()).default({}),
+  outputs: z.record(z.string().min(1), z.number()).default({}),
+  rate: z.number().nonnegative().default(0),
+});
+
+export const SpeciesSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  category: z.string().min(1),
+  sprites: z.array(AssetRefSchema).default([]),
+  params: z.record(z.string().min(1), z.unknown()).default({}),
+});
+
+export type AssetRef = z.infer<typeof AssetRefSchema>;
+export type Process = z.infer<typeof ProcessSchema>;
+export type Species = z.infer<typeof SpeciesSchema>;

--- a/src/core/ecs/ComponentStore.ts
+++ b/src/core/ecs/ComponentStore.ts
@@ -1,0 +1,49 @@
+import type { EntityId } from '@/core/ecs/EntityId';
+
+export class ComponentStore<T> implements Iterable<[EntityId, T]> {
+  private readonly components = new Map<EntityId, T>();
+
+  set(entityId: EntityId, component: T): void {
+    this.components.set(entityId, component);
+  }
+
+  get(entityId: EntityId): T | undefined {
+    return this.components.get(entityId);
+  }
+
+  has(entityId: EntityId): boolean {
+    return this.components.has(entityId);
+  }
+
+  delete(entityId: EntityId): boolean {
+    return this.components.delete(entityId);
+  }
+
+  clear(): void {
+    this.components.clear();
+  }
+
+  size(): number {
+    return this.components.size;
+  }
+
+  keys(): IterableIterator<EntityId> {
+    return this.components.keys();
+  }
+
+  values(): IterableIterator<T> {
+    return this.components.values();
+  }
+
+  entries(): IterableIterator<[EntityId, T]> {
+    return this.components.entries();
+  }
+
+  forEach(callback: (component: T, entityId: EntityId) => void): void {
+    this.components.forEach((component, entityId) => callback(component, entityId));
+  }
+
+  [Symbol.iterator](): IterableIterator<[EntityId, T]> {
+    return this.components[Symbol.iterator]();
+  }
+}

--- a/src/core/ecs/EntityId.ts
+++ b/src/core/ecs/EntityId.ts
@@ -1,0 +1,24 @@
+export type EntityId = number;
+
+export interface EntityIdGenerator {
+  next(): EntityId;
+  reset(next?: EntityId): void;
+  peek(): EntityId;
+}
+
+export function createEntityIdGenerator(start: EntityId = 0): EntityIdGenerator {
+  let current: EntityId = start;
+
+  return {
+    next(): EntityId {
+      current += 1;
+      return current;
+    },
+    reset(next: EntityId = 0): void {
+      current = next;
+    },
+    peek(): EntityId {
+      return current;
+    },
+  };
+}

--- a/src/core/ecs/System.ts
+++ b/src/core/ecs/System.ts
@@ -1,0 +1,5 @@
+import type { World } from '@/core/ecs/World';
+
+export type System = ((dtFixedMs: number, world: World) => void) & {
+  displayName?: string;
+};

--- a/src/core/ecs/World.ts
+++ b/src/core/ecs/World.ts
@@ -1,0 +1,89 @@
+import { ComponentStore } from '@/core/ecs/ComponentStore';
+import type { EntityId } from '@/core/ecs/EntityId';
+import { createEntityIdGenerator } from '@/core/ecs/EntityId';
+import type { System } from '@/core/ecs/System';
+
+export class World {
+  private readonly entities = new Set<EntityId>();
+  private readonly componentStores = new Map<string, ComponentStore<unknown>>();
+  private readonly systems: System[] = [];
+  private readonly generateEntityId = createEntityIdGenerator();
+
+  createEntity(): EntityId {
+    const entityId = this.generateEntityId.next();
+    this.entities.add(entityId);
+    return entityId;
+  }
+
+  destroyEntity(entityId: EntityId): boolean {
+    const removed = this.entities.delete(entityId);
+    if (!removed) {
+      return false;
+    }
+
+    for (const store of this.componentStores.values()) {
+      store.delete(entityId);
+    }
+
+    return true;
+  }
+
+  hasEntity(entityId: EntityId): boolean {
+    return this.entities.has(entityId);
+  }
+
+  get entityCount(): number {
+    return this.entities.size;
+  }
+
+  clearEntities(): void {
+    this.entities.clear();
+    for (const store of this.componentStores.values()) {
+      store.clear();
+    }
+    this.generateEntityId.reset();
+  }
+
+  registerComponentStore<T>(
+    key: string,
+    store: ComponentStore<T> = new ComponentStore<T>(),
+  ): ComponentStore<T> {
+    this.componentStores.set(key, store as ComponentStore<unknown>);
+    return store;
+  }
+
+  getComponentStore<T>(key: string): ComponentStore<T> | undefined {
+    return this.componentStores.get(key) as ComponentStore<T> | undefined;
+  }
+
+  getOrCreateComponentStore<T>(key: string): ComponentStore<T> {
+    const existing = this.getComponentStore<T>(key);
+    if (existing) {
+      return existing;
+    }
+
+    return this.registerComponentStore<T>(key);
+  }
+
+  getRegisteredComponentKeys(): string[] {
+    return Array.from(this.componentStores.keys());
+  }
+
+  addSystem(system: System): void {
+    this.systems.push(system);
+  }
+
+  clearSystems(): void {
+    this.systems.length = 0;
+  }
+
+  getSystems(): ReadonlyArray<System> {
+    return this.systems;
+  }
+
+  step(dtFixedMs: number): void {
+    for (const system of this.systems) {
+      system(dtFixedMs, this);
+    }
+  }
+}

--- a/src/core/services/ManifestService.ts
+++ b/src/core/services/ManifestService.ts
@@ -1,0 +1,111 @@
+import { assetService } from '@/core/services/AssetService';
+
+export type AssetManifest = {
+  images?: Record<string, string>;
+  atlases?: Record<string, { json: string; image: string }>;
+  fonts?: Record<string, string>;
+  version: string;
+};
+
+export class ManifestService {
+  private manifest: AssetManifest | null = null;
+  private inflight: Promise<AssetManifest | null> | null = null;
+  private readonly manifestPath = 'manifest.json';
+  private readonly crossOrigin = 'anonymous' as const;
+
+  constructor(private readonly assets = assetService) {}
+
+  async init(): Promise<AssetManifest | null> {
+    if (this.manifest) {
+      return this.manifest;
+    }
+
+    if (this.inflight) {
+      return this.inflight;
+    }
+
+    this.inflight = this.fetchManifest();
+    return this.inflight;
+  }
+
+  getManifest(): AssetManifest | null {
+    return this.manifest;
+  }
+
+  getCrossOrigin(): 'anonymous' {
+    return this.crossOrigin;
+  }
+
+  private async fetchManifest(): Promise<AssetManifest | null> {
+    const url = this.resolveUrl(this.manifestPath);
+
+    if (!url) {
+      return null;
+    }
+
+    try {
+      const response = await fetch(url, { mode: 'cors' });
+      if (!response.ok) {
+        console.warn(`Asset manifest request failed with status ${response.status}`);
+        return null;
+      }
+
+      const manifest = (await response.json()) as AssetManifest;
+      this.manifest = this.resolveManifest(manifest);
+      return this.manifest;
+    } catch (error) {
+      console.warn('Failed to load asset manifest', error);
+      return null;
+    }
+  }
+
+  private resolveManifest(manifest: AssetManifest): AssetManifest {
+    const resolved: AssetManifest = {
+      version: manifest.version,
+    };
+
+    if (manifest.images) {
+      resolved.images = this.resolveRecord(manifest.images);
+    }
+
+    if (manifest.fonts) {
+      resolved.fonts = this.resolveRecord(manifest.fonts);
+    }
+
+    if (manifest.atlases) {
+      resolved.atlases = Object.entries(manifest.atlases).reduce<
+        Record<string, { json: string; image: string }>
+      >((accumulator, [key, value]) => {
+        accumulator[key] = {
+          json: this.resolveUrl(value.json) ?? value.json,
+          image: this.resolveUrl(value.image) ?? value.image,
+        };
+        return accumulator;
+      }, {});
+    }
+
+    return resolved;
+  }
+
+  private resolveRecord(record: Record<string, string>): Record<string, string> {
+    return Object.entries(record).reduce<Record<string, string>>((accumulator, [key, path]) => {
+      accumulator[key] = this.resolveUrl(path) ?? path;
+      return accumulator;
+    }, {});
+  }
+
+  private resolveUrl(path: string | undefined): string | null {
+    if (!path) {
+      return null;
+    }
+
+    try {
+      return this.assets.resolve(path);
+    } catch (error) {
+      console.warn(`Failed to resolve asset path "${path}"`, error);
+      return null;
+    }
+  }
+}
+
+export const manifestService = new ManifestService();

--- a/src/core/services/Profiling.ts
+++ b/src/core/services/Profiling.ts
@@ -1,0 +1,59 @@
+const now = (): number => {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+
+  return Date.now();
+};
+
+export interface SystemTiming {
+  name: string;
+  durationMs: number;
+}
+
+export interface ProfilingSnapshot {
+  totalMs: number;
+  systems: SystemTiming[];
+}
+
+export class ProfilingService {
+  private readonly frameTimings = new Map<string, number>();
+  private snapshot: ProfilingSnapshot = { totalMs: 0, systems: [] };
+
+  measure<T>(name: string, fn: () => T): T {
+    const start = now();
+    try {
+      return fn();
+    } finally {
+      const duration = now() - start;
+      this.addTiming(name, duration);
+    }
+  }
+
+  addTiming(name: string, durationMs: number): void {
+    const current = this.frameTimings.get(name) ?? 0;
+    this.frameTimings.set(name, current + durationMs);
+  }
+
+  commit(): void {
+    const systems = Array.from(this.frameTimings.entries())
+      .map<SystemTiming>(([name, durationMs]) => ({ name, durationMs }))
+      .sort((a, b) => b.durationMs - a.durationMs);
+
+    const totalMs = systems.reduce((sum, entry) => sum + entry.durationMs, 0);
+
+    this.snapshot = { systems, totalMs };
+    this.frameTimings.clear();
+  }
+
+  reset(): void {
+    this.frameTimings.clear();
+    this.snapshot = { totalMs: 0, systems: [] };
+  }
+
+  getSnapshot(): ProfilingSnapshot {
+    return this.snapshot;
+  }
+}
+
+export const profiling = new ProfilingService();

--- a/src/core/services/StorageService.ts
+++ b/src/core/services/StorageService.ts
@@ -1,3 +1,7 @@
+import type { WorldState } from '@/core/sim/WorldState';
+
+const WORLD_STATE_KEY = 'world-state';
+
 export class StorageService {
   private readonly storage: Storage | null;
   private readonly fallback = new Map<string, string>();
@@ -87,6 +91,18 @@ export class StorageService {
     } else {
       this.fallback.delete(key);
     }
+  }
+
+  saveWorld(state: WorldState): void {
+    this.set(WORLD_STATE_KEY, state);
+  }
+
+  loadWorld(): WorldState | null {
+    return this.get<WorldState>(WORLD_STATE_KEY);
+  }
+
+  clearWorld(): void {
+    this.remove(WORLD_STATE_KEY);
   }
 }
 

--- a/src/core/sim/SimClock.ts
+++ b/src/core/sim/SimClock.ts
@@ -1,0 +1,138 @@
+import { eventBus } from '@/core/services/EventBus';
+import type { EventBus } from '@/core/services/EventBus';
+import type { CoreEvents, SimStatePayload, SimTickPayload } from '@/core/types';
+
+export interface SimClockOptions {
+  fixedDeltaMs?: number;
+  maxStepsPerFrame?: number;
+}
+
+type StepHandler = (dtFixedMs: number) => void;
+
+export class SimClock {
+  private accumulator = 0;
+  private elapsedMs = 0;
+  private tickCount = 0;
+  private paused = false;
+
+  private readonly fixedDeltaMs: number;
+  private readonly maxStepsPerFrame: number;
+  private readonly stepHandler: StepHandler;
+  private readonly bus: EventBus<CoreEvents>;
+
+  constructor(
+    stepHandler: StepHandler,
+    options: SimClockOptions = {},
+    bus: EventBus<CoreEvents> = eventBus,
+  ) {
+    this.stepHandler = stepHandler;
+    this.fixedDeltaMs = options.fixedDeltaMs ?? 100;
+    this.maxStepsPerFrame = options.maxStepsPerFrame ?? 5;
+    this.bus = bus;
+  }
+
+  advance(deltaMs: number): number {
+    if (this.paused) {
+      return 0;
+    }
+
+    if (!Number.isFinite(deltaMs)) {
+      return 0;
+    }
+
+    this.accumulator += deltaMs;
+    let steps = 0;
+
+    while (this.accumulator >= this.fixedDeltaMs && steps < this.maxStepsPerFrame) {
+      this.accumulator -= this.fixedDeltaMs;
+      this.executeStep();
+      steps += 1;
+    }
+
+    if (steps === this.maxStepsPerFrame && this.accumulator >= this.fixedDeltaMs) {
+      // Avoid spiralling by discarding the remainder when the simulation cannot catch up.
+      this.accumulator = 0;
+    }
+
+    return steps;
+  }
+
+  pause(): void {
+    if (this.paused) {
+      return;
+    }
+
+    this.paused = true;
+    this.emitState();
+  }
+
+  resume(): void {
+    if (!this.paused) {
+      return;
+    }
+
+    this.paused = false;
+    this.emitState();
+  }
+
+  toggle(): void {
+    if (this.paused) {
+      this.resume();
+    } else {
+      this.pause();
+    }
+  }
+
+  stepOnce(): void {
+    this.executeStep();
+  }
+
+  reset(): void {
+    this.accumulator = 0;
+    this.elapsedMs = 0;
+    this.tickCount = 0;
+    this.emitState();
+    this.emitTick(0);
+  }
+
+  get tick(): number {
+    return this.tickCount;
+  }
+
+  get time(): number {
+    return this.elapsedMs;
+  }
+
+  get delta(): number {
+    return this.fixedDeltaMs;
+  }
+
+  get isPaused(): boolean {
+    return this.paused;
+  }
+
+  private executeStep(): void {
+    this.tickCount += 1;
+    this.elapsedMs += this.fixedDeltaMs;
+    this.stepHandler(this.fixedDeltaMs);
+    this.emitTick(this.fixedDeltaMs);
+  }
+
+  private emitTick(deltaMs: number): void {
+    const payload: SimTickPayload = {
+      tick: this.tickCount,
+      elapsedMs: this.elapsedMs,
+      deltaMs,
+    };
+    this.bus.emit('sim:tick', payload);
+  }
+
+  private emitState(): void {
+    const payload: SimStatePayload = {
+      tick: this.tickCount,
+      elapsedMs: this.elapsedMs,
+      paused: this.paused,
+    };
+    this.bus.emit('sim:state', payload);
+  }
+}

--- a/src/core/sim/SimConfig.ts
+++ b/src/core/sim/SimConfig.ts
@@ -1,0 +1,19 @@
+import { MS_PER_TICK } from '@/core/sim/Units';
+
+export interface SimConfig {
+  /** Fixed number of milliseconds simulated per tick. */
+  tickDurationMs: number;
+  /** Placeholder baseline growth energy per tick. */
+  growthEnergyPerTick: number;
+  /** Placeholder baseline decay energy per tick. */
+  decayEnergyPerTick: number;
+  /** Placeholder baseline light gathered per tick. */
+  lightPerTick: number;
+}
+
+export const DEFAULT_SIM_CONFIG: SimConfig = {
+  tickDurationMs: MS_PER_TICK,
+  growthEnergyPerTick: 1,
+  decayEnergyPerTick: 1,
+  lightPerTick: 1,
+};

--- a/src/core/sim/Units.ts
+++ b/src/core/sim/Units.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared simulation unit references.
+ *
+ * These values define the base scalar units used throughout the Terrarium
+ * simulation. Concrete species, processes, and balancing will derive from
+ * these references in later phases. For now they serve as documentation for
+ * the fixed-step simulation loop.
+ */
+
+/** Milliseconds advanced per fixed simulation tick. */
+export const MS_PER_TICK = 100;
+
+/**
+ * Baseline metabolic energy unit. Future species will consume and generate
+ * energy in integer multiples of this constant.
+ */
+export const ENERGY_UNIT = 1;
+
+/**
+ * Baseline illumination unit for photosynthesis and diurnal cycles.
+ */
+export const LIGHT_UNIT = 1;

--- a/src/core/sim/WorldState.ts
+++ b/src/core/sim/WorldState.ts
@@ -1,0 +1,44 @@
+import type { EntityId } from '@/core/ecs/EntityId';
+
+export interface ComponentState<T = unknown> {
+  key: string;
+  values: Array<[EntityId, T]>;
+}
+
+export interface WorldState {
+  version: string;
+  tick: number;
+  entities: EntityId[];
+  components: ComponentState[];
+}
+
+export const WORLD_STATE_VERSION = '0.1.0';
+
+export function createEmptyWorldState(): WorldState {
+  return {
+    version: WORLD_STATE_VERSION,
+    tick: 0,
+    entities: [],
+    components: [],
+  };
+}
+
+export function serializeWorldState(state: WorldState): string {
+  return JSON.stringify(state);
+}
+
+export function deserializeWorldState(serialized: string): WorldState {
+  const raw = JSON.parse(serialized) as WorldState;
+
+  return {
+    version: raw.version,
+    tick: raw.tick,
+    entities: raw.entities.map((entity) => normalizeEntityId(entity)),
+    components: raw.components.map((component) => ({
+      key: component.key,
+      values: component.values.map(([entity, value]) => [normalizeEntityId(entity), value]),
+    })),
+  };
+}
+
+const normalizeEntityId = (value: unknown): EntityId => Number(value);

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -7,8 +7,29 @@ export interface TimeTickPayload {
   fps: number;
 }
 
+export interface SimTickPayload {
+  tick: number;
+  elapsedMs: number;
+  deltaMs: number;
+}
+
+export interface SimStatePayload {
+  tick: number;
+  elapsedMs: number;
+  paused: boolean;
+}
+
+export type SimCommandAction = 'pause' | 'resume' | 'step' | 'reset';
+
+export interface SimCommandPayload {
+  action: SimCommandAction;
+}
+
 export interface CoreEvents extends EventMap {
-  'debug:toggle': boolean | undefined;
+  'devpanel:toggle': boolean | undefined;
+  'sim:tick': SimTickPayload;
+  'sim:state': SimStatePayload;
+  'sim:command': SimCommandPayload;
   'time:tick': TimeTickPayload;
 }
 

--- a/src/game/GameBoot.ts
+++ b/src/game/GameBoot.ts
@@ -1,6 +1,9 @@
 import Phaser from 'phaser';
 
 import { BACKGROUND_COLOR, SCENES } from '@/core/config';
+import { eventBus } from '@/core/services/EventBus';
+import { storageService } from '@/core/services/StorageService';
+import { manifestService } from '@/core/services/ManifestService';
 
 export class GameBoot extends Phaser.Scene {
   constructor() {
@@ -8,10 +11,14 @@ export class GameBoot extends Phaser.Scene {
   }
 
   preload(): void {
-    this.load.setCORS('anonymous');
+    this.load.setCORS(manifestService.getCrossOrigin());
   }
 
   create(): void {
+    eventBus.clear();
+    void manifestService.init();
+    const savedState = storageService.loadWorld();
+    this.registry.set('world:state', savedState);
     this.cameras.main.setBackgroundColor(BACKGROUND_COLOR);
     this.scene.start(SCENES.PRELOAD);
   }

--- a/src/game/GamePlay.ts
+++ b/src/game/GamePlay.ts
@@ -1,22 +1,34 @@
 import Phaser from 'phaser';
 
 import { DEBUG_SPRITE_KEY, GAME_HEIGHT, GAME_WIDTH, SCENES } from '@/core/config';
+import { World } from '@/core/ecs/World';
+import { SimClock } from '@/core/sim/SimClock';
+import { MS_PER_TICK } from '@/core/sim/Units';
+import { profiling } from '@/core/services/Profiling';
 import { eventBus } from '@/core/services/EventBus';
-import { time } from '@/core/services/Time';
+import type { CoreEvents } from '@/core/types';
+import { SIM_SYSTEMS } from '@/game/systems/Simulation';
+import { setupInput } from '@/game/systems/Input';
+import { RenderingBridge } from '@/game/systems/Rendering';
 
 export class GamePlay extends Phaser.Scene {
-  private debugKey?: Phaser.Input.Keyboard.Key;
+  private world!: World;
+  private clock!: SimClock;
+  private rendering!: RenderingBridge;
+  private unsubscribeCommand?: () => void;
 
   constructor() {
     super(SCENES.PLAY);
   }
 
   create(): void {
+    this.cameras.main.setRoundPixels(true);
+
     const sprite = this.add.image(GAME_WIDTH / 2, GAME_HEIGHT / 2 - 12, DEBUG_SPRITE_KEY);
     sprite.setOrigin(0.5);
     sprite.setScale(16);
 
-    const headline = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT - 32, 'Terrarium Engine Ready', {
+    const headline = this.add.text(GAME_WIDTH / 2, GAME_HEIGHT - 32, 'Simulation Spine Online', {
       fontFamily: 'Courier New, monospace',
       fontSize: '12px',
       color: '#f0f6fc',
@@ -28,7 +40,7 @@ export class GamePlay extends Phaser.Scene {
     const instructions = this.add.text(
       GAME_WIDTH / 2,
       GAME_HEIGHT - 16,
-      'Press D to toggle debug overlay',
+      'Press ` to toggle dev panel',
       {
         fontFamily: 'Courier New, monospace',
         fontSize: '10px',
@@ -39,18 +51,71 @@ export class GamePlay extends Phaser.Scene {
     instructions.setOrigin(0.5);
     instructions.setResolution(2);
 
-    this.debugKey = this.input.keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.D);
+    this.world = new World();
+    this.rendering = new RenderingBridge(this);
+
+    SIM_SYSTEMS.forEach((system) => this.world.addSystem(system));
+
+    this.clock = new SimClock((dt) => this.stepSimulation(dt), {
+      fixedDeltaMs: MS_PER_TICK,
+      maxStepsPerFrame: 8,
+    });
+    this.clock.reset();
+
+    this.unsubscribeCommand = eventBus.on('sim:command', (payload) => this.handleCommand(payload));
+
+    setupInput(this);
 
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
-      this.debugKey?.destroy();
+      this.unsubscribeCommand?.();
     });
   }
 
   update(_time: number, delta: number): void {
-    if (this.debugKey && Phaser.Input.Keyboard.JustDown(this.debugKey)) {
-      eventBus.emit('debug:toggle', undefined);
+    this.clock.advance(delta);
+  }
+
+  private stepSimulation(dt: number): void {
+    if (import.meta.env.DEV) {
+      for (const system of this.world.getSystems()) {
+        const name = system.displayName ?? system.name ?? 'System';
+        profiling.measure(name, () => {
+          system(dt, this.world);
+        });
+      }
+      profiling.commit();
+    } else {
+      this.world.step(dt);
     }
 
-    time.update(delta);
+    this.rendering.sync(this.world);
+  }
+
+  private handleCommand(payload: CoreEvents['sim:command']): void {
+    switch (payload.action) {
+      case 'pause':
+        this.clock.pause();
+        break;
+      case 'resume':
+        this.clock.resume();
+        break;
+      case 'step':
+        this.clock.stepOnce();
+        break;
+      case 'reset':
+        this.resetWorld();
+        break;
+      default:
+        break;
+    }
+  }
+
+  private resetWorld(): void {
+    this.world.clearEntities();
+    if (import.meta.env.DEV) {
+      profiling.reset();
+      profiling.commit();
+    }
+    this.clock.reset();
   }
 }

--- a/src/game/GamePreload.ts
+++ b/src/game/GamePreload.ts
@@ -1,29 +1,20 @@
 import Phaser from 'phaser';
 
-import { DEBUG_SPRITE_KEY, DEBUG_SPRITE_PATH, SCENES } from '@/core/config';
+import { DEBUG_SPRITE_KEY, SCENES } from '@/core/config';
 import { assetService } from '@/core/services/AssetService';
+import { manifestService } from '@/core/services/ManifestService';
 
 export class GamePreload extends Phaser.Scene {
-  private fallbackLoaded = false;
-
   constructor() {
     super(SCENES.PRELOAD);
   }
 
   preload(): void {
-    this.load.setCORS('anonymous');
-    this.load.image(DEBUG_SPRITE_KEY, assetService.resolve(DEBUG_SPRITE_PATH));
+    this.load.setCORS(manifestService.getCrossOrigin());
+    this.load.image(DEBUG_SPRITE_KEY, assetService.placeholderPixel());
 
     this.load.once(Phaser.Loader.Events.COMPLETE, () => {
       this.scene.start(SCENES.PLAY);
-    });
-
-    this.load.on(Phaser.Loader.Events.FILE_LOAD_ERROR, (file: Phaser.Loader.File) => {
-      if (file.key === DEBUG_SPRITE_KEY && !this.fallbackLoaded) {
-        this.fallbackLoaded = true;
-        this.load.image(DEBUG_SPRITE_KEY, assetService.placeholderPixel());
-        this.load.start();
-      }
     });
   }
 }

--- a/src/game/systems/Input.ts
+++ b/src/game/systems/Input.ts
@@ -1,0 +1,24 @@
+import Phaser from 'phaser';
+
+import { eventBus } from '@/core/services/EventBus';
+
+export function setupInput(scene: Phaser.Scene): void {
+  if (!scene.input.keyboard || !import.meta.env.DEV) {
+    return;
+  }
+
+  const toggleKey = scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.BACKTICK);
+
+  const handleUpdate = () => {
+    if (Phaser.Input.Keyboard.JustDown(toggleKey)) {
+      eventBus.emit('devpanel:toggle', undefined);
+    }
+  };
+
+  scene.events.on(Phaser.Scenes.Events.UPDATE, handleUpdate);
+
+  scene.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+    scene.events.off(Phaser.Scenes.Events.UPDATE, handleUpdate);
+    toggleKey.destroy();
+  });
+}

--- a/src/game/systems/Rendering.ts
+++ b/src/game/systems/Rendering.ts
@@ -1,0 +1,13 @@
+import type Phaser from 'phaser';
+
+import type { World } from '@/core/ecs/World';
+
+export class RenderingBridge {
+  constructor(private readonly scene: Phaser.Scene) {}
+
+  sync(world: World): void {
+    void world;
+    // Rendering bridge placeholder. Future phases will synchronize ECS state
+    // with Phaser display objects here.
+  }
+}

--- a/src/game/systems/Simulation.ts
+++ b/src/game/systems/Simulation.ts
@@ -1,0 +1,17 @@
+import type { System } from '@/core/ecs/System';
+
+const lifecycleSystem: System = ((dt, world) => {
+  void dt;
+  void world;
+  // Placeholder lifecycle system. Species-specific logic will be added later.
+}) as System;
+lifecycleSystem.displayName = 'Sim::Lifecycle';
+
+const metabolismSystem: System = ((dt, world) => {
+  void dt;
+  void world;
+  // Placeholder metabolism system.
+}) as System;
+metabolismSystem.displayName = 'Sim::Metabolism';
+
+export const SIM_SYSTEMS: System[] = [lifecycleSystem, metabolismSystem];

--- a/src/index.html
+++ b/src/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,12 @@
 import Phaser from 'phaser';
 
 import { GameConfig } from '@/game/GameConfig';
-import { DebugOverlay } from '@/ui/overlay/DebugOverlay';
-import { eventBus } from '@/core/services/EventBus';
+import { DevPanel } from '@/ui/overlay/DevPanel';
 
 import '@/styles/index.css';
 
 const game = new Phaser.Game(GameConfig);
-const debugOverlay = new DebugOverlay();
+const devPanel = import.meta.env.DEV ? new DevPanel() : null;
 
 declare global {
   interface Window {
@@ -17,14 +16,8 @@ declare global {
 
 window.terrariumGame = game;
 
-window.addEventListener('keydown', (event: KeyboardEvent) => {
-  if (event.key.toLowerCase() === 'd') {
-    eventBus.emit('debug:toggle', undefined);
-  }
-});
-
 window.addEventListener('beforeunload', () => {
-  debugOverlay.destroy();
+  devPanel?.destroy();
   window.terrariumGame?.destroy(true);
 });
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -31,43 +31,72 @@ canvas {
   background: #1d1f21;
 }
 
-.debug-overlay {
+.dev-panel {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  padding: 0.75rem 1rem;
-  background: rgba(0, 0, 0, 0.85);
-  color: #39ff14;
+  top: 0.75rem;
+  left: 0.75rem;
+  min-width: 240px;
+  padding: 0.75rem;
+  background: rgba(11, 13, 15, 0.92);
+  border: 1px solid #2b2f36;
+  border-radius: 6px;
+  color: #f0f6fc;
   font-size: 0.75rem;
-  letter-spacing: 0.08em;
-  transform: translateY(-100%);
-  transition: transform 0.2s ease-in-out;
-  pointer-events: none;
-  text-transform: uppercase;
-}
-
-.debug-overlay.is-visible {
-  transform: translateY(0);
-}
-
-.debug-overlay h1 {
-  margin: 0 0 0.25rem;
-  font-size: 0.9rem;
-}
-
-.debug-overlay p {
-  margin: 0;
   line-height: 1.4;
+  letter-spacing: 0.04em;
+  transform: translateY(-140%);
+  opacity: 0;
+  transition:
+    transform 0.2s ease-in-out,
+    opacity 0.2s ease-in-out;
+  pointer-events: none;
+  z-index: 20;
 }
 
-.debug-overlay__metrics {
-  margin-top: 0.25rem;
+.dev-panel.is-visible {
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.dev-panel__stats {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.dev-panel__controls {
   display: flex;
-  gap: 1rem;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
-.debug-overlay__metrics span {
-  display: inline-flex;
+.dev-panel__controls button {
+  flex: 1 1 auto;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #394049;
+  border-radius: 4px;
+  background: #16191d;
+  color: #f0f6fc;
+  font-family: inherit;
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+}
+
+.dev-panel__controls button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.dev-panel__timings {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
   gap: 0.25rem;
+}
+
+.dev-panel__timings-total {
+  font-weight: 600;
 }

--- a/src/test/core/StorageService.test.ts
+++ b/src/test/core/StorageService.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { StorageService } from '@/core/services/StorageService';
+import { WORLD_STATE_VERSION } from '@/core/sim/WorldState';
 
 describe('StorageService', () => {
   let storage: StorageService;
@@ -28,5 +29,21 @@ describe('StorageService', () => {
     storage.remove('ephemeral');
 
     expect(storage.get('ephemeral')).toBeNull();
+  });
+
+  it('serializes world state helpers', () => {
+    const state = {
+      version: WORLD_STATE_VERSION,
+      tick: 5,
+      entities: [1, 2],
+      components: [],
+    };
+
+    storage.saveWorld(state);
+
+    expect(storage.loadWorld()).toEqual(state);
+
+    storage.clearWorld();
+    expect(storage.loadWorld()).toBeNull();
   });
 });

--- a/src/ui/overlay/DevPanel.ts
+++ b/src/ui/overlay/DevPanel.ts
@@ -1,0 +1,115 @@
+import { profiling } from '@/core/services/Profiling';
+import { eventBus } from '@/core/services/EventBus';
+import type { ProfilingService } from '@/core/services/Profiling';
+import type { CoreEvents } from '@/core/types';
+
+export class DevPanel {
+  private readonly container: HTMLDivElement;
+  private readonly stats: HTMLDivElement;
+  private readonly timings: HTMLUListElement;
+  private readonly buttons: Record<'pause' | 'play' | 'step' | 'reset', HTMLButtonElement>;
+  private readonly unsubscribes: Array<() => void> = [];
+  private visible = false;
+  private paused = false;
+
+  constructor(
+    private readonly bus = eventBus,
+    private readonly profiler: ProfilingService = profiling,
+  ) {
+    this.container = document.createElement('div');
+    this.container.className = 'dev-panel';
+
+    this.stats = document.createElement('div');
+    this.stats.className = 'dev-panel__stats';
+    this.stats.textContent = 'Sim — tick: 0 | time: 0.0s | dt: 0ms';
+
+    this.timings = document.createElement('ul');
+    this.timings.className = 'dev-panel__timings';
+
+    const controls = document.createElement('div');
+    controls.className = 'dev-panel__controls';
+
+    this.buttons = {
+      pause: this.createButton('Pause', () => this.emitCommand('pause')),
+      play: this.createButton('Play', () => this.emitCommand('resume')),
+      step: this.createButton('Step', () => this.emitCommand('step')),
+      reset: this.createButton('Reset', () => this.emitCommand('reset')),
+    };
+
+    controls.append(this.buttons.pause, this.buttons.play, this.buttons.step, this.buttons.reset);
+
+    this.container.append(this.stats, controls, this.timings);
+    document.body.appendChild(this.container);
+
+    this.unsubscribes.push(
+      this.bus.on('devpanel:toggle', (visible) => this.toggle(visible)),
+      this.bus.on('sim:tick', (payload) => this.updateTick(payload)),
+      this.bus.on('sim:state', (payload) => this.updateState(payload)),
+    );
+
+    this.updateControls();
+  }
+
+  destroy(): void {
+    this.unsubscribes.forEach((unsubscribe) => unsubscribe());
+    this.container.remove();
+  }
+
+  private toggle(visible?: CoreEvents['devpanel:toggle']): void {
+    const nextVisible = typeof visible === 'boolean' ? visible : !this.visible;
+    this.visible = nextVisible;
+    this.container.classList.toggle('is-visible', this.visible);
+  }
+
+  private updateTick(payload: CoreEvents['sim:tick']): void {
+    const seconds = (payload.elapsedMs / 1000).toFixed(2);
+    this.stats.textContent = `Sim — tick: ${payload.tick} | time: ${seconds}s | dt: ${payload.deltaMs}ms`;
+    this.updateTimings();
+  }
+
+  private updateState(payload: CoreEvents['sim:state']): void {
+    this.paused = payload.paused;
+    this.updateControls();
+  }
+
+  private updateControls(): void {
+    this.buttons.pause.disabled = this.paused;
+    this.buttons.play.disabled = !this.paused;
+    this.buttons.step.disabled = !this.paused;
+  }
+
+  private updateTimings(): void {
+    const snapshot = this.profiler.getSnapshot();
+    this.timings.innerHTML = '';
+
+    if (snapshot.systems.length === 0) {
+      const item = document.createElement('li');
+      item.textContent = 'No systems profiled';
+      this.timings.appendChild(item);
+      return;
+    }
+
+    const totalLabel = document.createElement('li');
+    totalLabel.textContent = `Total ${snapshot.totalMs.toFixed(3)}ms`;
+    totalLabel.className = 'dev-panel__timings-total';
+    this.timings.appendChild(totalLabel);
+
+    snapshot.systems.forEach((entry) => {
+      const item = document.createElement('li');
+      item.textContent = `${entry.name} — ${entry.durationMs.toFixed(3)}ms`;
+      this.timings.appendChild(item);
+    });
+  }
+
+  private emitCommand(action: CoreEvents['sim:command']['action']): void {
+    this.bus.emit('sim:command', { action });
+  }
+
+  private createButton(label: string, onClick: () => void): HTMLButtonElement {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = label;
+    button.addEventListener('click', onClick);
+    return button;
+  }
+}

--- a/test/core/ecs/ComponentStore.test.ts
+++ b/test/core/ecs/ComponentStore.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { ComponentStore } from '@/core/ecs/ComponentStore';
+
+const createStore = () => new ComponentStore<{ name: string }>();
+
+describe('ComponentStore', () => {
+  it('stores and retrieves components', () => {
+    const store = createStore();
+    store.set(1, { name: 'alpha' });
+    store.set(2, { name: 'beta' });
+
+    expect(store.get(1)).toEqual({ name: 'alpha' });
+    expect(store.get(2)).toEqual({ name: 'beta' });
+    expect(store.get(3)).toBeUndefined();
+  });
+
+  it('tracks entity membership', () => {
+    const store = createStore();
+    store.set(5, { name: 'delta' });
+
+    expect(store.has(5)).toBe(true);
+    expect(store.has(6)).toBe(false);
+
+    store.delete(5);
+    expect(store.has(5)).toBe(false);
+  });
+
+  it('supports iteration over entries', () => {
+    const store = createStore();
+    store.set(1, { name: 'a' });
+    store.set(2, { name: 'b' });
+    store.set(3, { name: 'c' });
+
+    const entries = Array.from(store.entries());
+
+    expect(entries).toEqual([
+      [1, { name: 'a' }],
+      [2, { name: 'b' }],
+      [3, { name: 'c' }],
+    ]);
+  });
+
+  it('allows deletion while iterating', () => {
+    const store = createStore();
+    store.set(1, { name: 'keeper' });
+    store.set(2, { name: 'remove-me' });
+
+    for (const [entityId] of store) {
+      if (entityId === 2) {
+        store.delete(entityId);
+      }
+    }
+
+    expect(Array.from(store.keys())).toEqual([1]);
+  });
+});

--- a/test/core/sim/WorldState.test.ts
+++ b/test/core/sim/WorldState.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  WORLD_STATE_VERSION,
+  deserializeWorldState,
+  serializeWorldState,
+  type WorldState,
+} from '@/core/sim/WorldState';
+
+const createState = (): WorldState => ({
+  version: WORLD_STATE_VERSION,
+  tick: 12,
+  entities: [1, 2, 3],
+  components: [
+    {
+      key: 'position',
+      values: [
+        [1, { x: 1, y: 1 }],
+        [2, { x: 2, y: 3 }],
+      ],
+    },
+    {
+      key: 'energy',
+      values: [
+        [1, { value: 10 }],
+        [3, { value: 15 }],
+      ],
+    },
+  ],
+});
+
+describe('WorldState', () => {
+  it('serializes and deserializes world state', () => {
+    const original = createState();
+    const serialized = serializeWorldState(original);
+    const restored = deserializeWorldState(serialized);
+
+    expect(restored).toEqual(original);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["src", "vite.config.ts"],
+  "include": ["src", "test", "vite.config.ts"],
   "references": []
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,5 +29,23 @@ export default defineConfig(({ mode }) => {
       emptyOutDir: true,
       sourcemap: true,
     },
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      include: ['test/**/*.test.ts', '../test/**/*.test.ts'],
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'html'],
+        reportsDirectory: resolve(rootDir, 'coverage'),
+        lines: 70,
+        functions: 70,
+        statements: 70,
+        branches: 60,
+        enabled: true,
+        all: false,
+        include: ['core/services/**/*.ts', 'core/ecs/**/*.ts', 'core/sim/**/*.ts'],
+        exclude: ['**/*.d.ts'],
+      },
+    },
   };
 });


### PR DESCRIPTION
## Summary
- add ECS-lite primitives, simulation clock, and shared unit/config modules to drive deterministic ticks
- integrate profiling, manifest bootstrapping, and developer panel controls into the Phaser scenes with stub systems
- define zod schemas plus storage helpers and add Vitest coverage configuration with new component/world state tests

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cfa5e8e350832b941e4cdeded20113