### PR TITLE
Add demo ECS entities with spawn and rendering support

### DIFF
--- a/src/core/ecs/World.ts
+++ b/src/core/ecs/World.ts
@@ -3,9 +3,11 @@ import type { EntityId } from '@/core/ecs/EntityId';
 import { createEntityIdGenerator } from '@/core/ecs/EntityId';
 import type { System } from '@/core/ecs/System';
 
+export type ComponentKey = string | symbol;
+
 export class World {
   private readonly entities = new Set<EntityId>();
-  private readonly componentStores = new Map<string, ComponentStore<unknown>>();
+  private readonly componentStores = new Map<ComponentKey, ComponentStore<unknown>>();
   private readonly systems: System[] = [];
   private readonly generateEntityId = createEntityIdGenerator();
 
@@ -45,18 +47,18 @@ export class World {
   }
 
   registerComponentStore<T>(
-    key: string,
+    key: ComponentKey,
     store: ComponentStore<T> = new ComponentStore<T>(),
   ): ComponentStore<T> {
     this.componentStores.set(key, store as ComponentStore<unknown>);
     return store;
   }
 
-  getComponentStore<T>(key: string): ComponentStore<T> | undefined {
+  getComponentStore<T>(key: ComponentKey): ComponentStore<T> | undefined {
     return this.componentStores.get(key) as ComponentStore<T> | undefined;
   }
 
-  getOrCreateComponentStore<T>(key: string): ComponentStore<T> {
+  getOrCreateComponentStore<T>(key: ComponentKey): ComponentStore<T> {
     const existing = this.getComponentStore<T>(key);
     if (existing) {
       return existing;
@@ -65,7 +67,7 @@ export class World {
     return this.registerComponentStore<T>(key);
   }
 
-  getRegisteredComponentKeys(): string[] {
+  getRegisteredComponentKeys(): ComponentKey[] {
     return Array.from(this.componentStores.keys());
   }
 

--- a/src/core/ecs/components/Lifetime.ts
+++ b/src/core/ecs/components/Lifetime.ts
@@ -1,0 +1,5 @@
+export interface Lifetime {
+  ticksToLive: number;
+}
+
+export const LifetimeKey = Symbol('Lifetime');

--- a/src/core/ecs/components/Position.ts
+++ b/src/core/ecs/components/Position.ts
@@ -1,0 +1,6 @@
+export interface Position {
+  x: number;
+  y: number;
+}
+
+export const PositionKey = Symbol('Position');

--- a/src/core/ecs/components/RenderDot.ts
+++ b/src/core/ecs/components/RenderDot.ts
@@ -1,0 +1,6 @@
+export interface RenderDot {
+  radius: number;
+  color?: number;
+}
+
+export const RenderDotKey = Symbol('RenderDot');

--- a/src/core/ecs/components/RenderLabel.ts
+++ b/src/core/ecs/components/RenderLabel.ts
@@ -1,0 +1,7 @@
+export interface RenderLabel {
+  text: string;
+  size?: number;
+  color?: number;
+}
+
+export const RenderLabelKey = Symbol('RenderLabel');

--- a/src/game/systems/GarbageCollect.ts
+++ b/src/game/systems/GarbageCollect.ts
@@ -1,0 +1,31 @@
+import type { EntityId } from '@/core/ecs/EntityId';
+import type { System } from '@/core/ecs/System';
+import type { Lifetime } from '@/core/ecs/components/Lifetime';
+import { LifetimeKey } from '@/core/ecs/components/Lifetime';
+
+export const garbageCollectSystem: System = ((dt, world) => {
+  void dt;
+
+  const lifetimeStore = world.getComponentStore<Lifetime>(LifetimeKey);
+  if (!lifetimeStore) {
+    return;
+  }
+
+  const entitiesToRemove: EntityId[] = [];
+
+  for (const [entityId, lifetime] of lifetimeStore) {
+    if (lifetime.ticksToLive <= 0) {
+      entitiesToRemove.push(entityId);
+      continue;
+    }
+
+    const nextTicks = lifetime.ticksToLive - 1;
+    lifetimeStore.set(entityId, { ticksToLive: nextTicks });
+  }
+
+  for (const entityId of entitiesToRemove) {
+    world.destroyEntity(entityId);
+  }
+}) as System;
+
+garbageCollectSystem.displayName = 'Sim::GarbageCollect';

--- a/src/game/systems/Rendering.ts
+++ b/src/game/systems/Rendering.ts
@@ -1,13 +1,147 @@
-import type Phaser from 'phaser';
+import Phaser from 'phaser';
 
+import type { ComponentStore } from '@/core/ecs/ComponentStore';
+import type { EntityId } from '@/core/ecs/EntityId';
 import type { World } from '@/core/ecs/World';
+import type { Position } from '@/core/ecs/components/Position';
+import { PositionKey } from '@/core/ecs/components/Position';
+import type { RenderDot } from '@/core/ecs/components/RenderDot';
+import { RenderDotKey } from '@/core/ecs/components/RenderDot';
+import type { RenderLabel } from '@/core/ecs/components/RenderLabel';
+import { RenderLabelKey } from '@/core/ecs/components/RenderLabel';
+
+const DEFAULT_DOT_COLOR = 0xffffff;
+const DEFAULT_LABEL_COLOR = 0xffffff;
+
+function toHexColor(value: number | undefined, fallback: number): string {
+  const normalized = value ?? fallback;
+  const hex = normalized.toString(16).padStart(6, '0');
+  return `#${hex}`;
+}
 
 export class RenderingBridge {
+  private readonly dotGraphics = new Map<EntityId, Phaser.GameObjects.Graphics>();
+  private readonly labelTexts = new Map<EntityId, Phaser.GameObjects.Text>();
+
   constructor(private readonly scene: Phaser.Scene) {}
 
   sync(world: World): void {
-    void world;
-    // Rendering bridge placeholder. Future phases will synchronize ECS state
-    // with Phaser display objects here.
+    const positionStore = world.getComponentStore<Position>(PositionKey);
+    if (!positionStore) {
+      this.clear();
+      return;
+    }
+
+    this.syncDots(world, positionStore);
+    this.syncLabels(world, positionStore);
+  }
+
+  clear(): void {
+    for (const graphics of this.dotGraphics.values()) {
+      graphics.destroy();
+    }
+    this.dotGraphics.clear();
+
+    for (const text of this.labelTexts.values()) {
+      text.destroy();
+    }
+    this.labelTexts.clear();
+  }
+
+  private syncDots(world: World, positionStore: ComponentStore<Position>): void {
+    const dotStore = world.getComponentStore<RenderDot>(RenderDotKey);
+    const active = new Set<EntityId>();
+
+    if (dotStore) {
+      for (const [entityId, dot] of dotStore) {
+        const position = positionStore.get(entityId);
+        if (!position) {
+          continue;
+        }
+
+        const graphics = this.getOrCreateDot(entityId);
+        const x = Math.round(position.x);
+        const y = Math.round(position.y);
+        const radius = Math.max(0, dot.radius);
+
+        graphics.clear();
+
+        if (radius > 0) {
+          graphics.fillStyle(dot.color ?? DEFAULT_DOT_COLOR, 1);
+          graphics.fillCircle(x, y, radius);
+        }
+
+        active.add(entityId);
+      }
+    }
+
+    for (const [entityId, graphics] of this.dotGraphics) {
+      if (!active.has(entityId)) {
+        graphics.destroy();
+        this.dotGraphics.delete(entityId);
+      }
+    }
+  }
+
+  private syncLabels(world: World, positionStore: ComponentStore<Position>): void {
+    const labelStore = world.getComponentStore<RenderLabel>(RenderLabelKey);
+    const active = new Set<EntityId>();
+
+    if (labelStore) {
+      for (const [entityId, label] of labelStore) {
+        const position = positionStore.get(entityId);
+        if (!position) {
+          continue;
+        }
+
+        const textObject = this.getOrCreateLabel(entityId);
+        const x = Math.round(position.x);
+        const y = Math.round(position.y);
+        const size = Math.max(1, label.size ?? 8);
+
+        textObject.setPosition(x, y);
+        textObject.setText(label.text);
+        textObject.setFontSize(size);
+        textObject.setColor(toHexColor(label.color, DEFAULT_LABEL_COLOR));
+
+        active.add(entityId);
+      }
+    }
+
+    for (const [entityId, text] of this.labelTexts) {
+      if (!active.has(entityId)) {
+        text.destroy();
+        this.labelTexts.delete(entityId);
+      }
+    }
+  }
+
+  private getOrCreateDot(entityId: EntityId): Phaser.GameObjects.Graphics {
+    let graphics = this.dotGraphics.get(entityId);
+    if (!graphics) {
+      graphics = this.scene.add.graphics();
+      graphics.setScrollFactor(1, 1);
+      graphics.setDepth(10);
+      this.dotGraphics.set(entityId, graphics);
+    }
+    return graphics;
+  }
+
+  private getOrCreateLabel(entityId: EntityId): Phaser.GameObjects.Text {
+    let text = this.labelTexts.get(entityId);
+    if (!text) {
+      text = this.scene.add.text(0, 0, '', {
+        fontFamily: 'Courier New, monospace',
+        fontSize: '8px',
+        color: toHexColor(undefined, DEFAULT_LABEL_COLOR),
+        align: 'center',
+      });
+      text.setOrigin(0.5);
+      text.setScrollFactor(1, 1);
+      text.setDepth(11);
+      text.setResolution(2);
+      this.labelTexts.set(entityId, text);
+    }
+    return text;
   }
 }

--- a/src/game/systems/Spawning.ts
+++ b/src/game/systems/Spawning.ts
@@ -1,0 +1,109 @@
+import type { EntityId } from '@/core/ecs/EntityId';
+import type { System } from '@/core/ecs/System';
+import type { Lifetime } from '@/core/ecs/components/Lifetime';
+import { LifetimeKey } from '@/core/ecs/components/Lifetime';
+import type { Position } from '@/core/ecs/components/Position';
+import { PositionKey } from '@/core/ecs/components/Position';
+import type { RenderDot } from '@/core/ecs/components/RenderDot';
+import { RenderDotKey } from '@/core/ecs/components/RenderDot';
+import type { RenderLabel } from '@/core/ecs/components/RenderLabel';
+import { RenderLabelKey } from '@/core/ecs/components/RenderLabel';
+
+export type SpawnRequest =
+  | { kind: 'dot'; x: number; y: number; radius?: number; color?: number; ttl?: number }
+  | { kind: 'label'; x: number; y: number; text: string; size?: number; color?: number; ttl?: number };
+
+const spawnQueue: SpawnRequest[] = [];
+const trackedEntities = new Set<EntityId>();
+let despawnAllRequested = false;
+
+export function queueSpawn(request: SpawnRequest): void {
+  spawnQueue.push(request);
+}
+
+export function queueDespawnAll(): void {
+  spawnQueue.length = 0;
+  despawnAllRequested = true;
+}
+
+function normalizeLifetime(value: number | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!Number.isFinite(value)) {
+    return undefined;
+  }
+
+  const clamped = Math.max(0, Math.floor(value));
+  return Number.isFinite(clamped) ? clamped : undefined;
+}
+
+export const spawningSystem: System = ((dt, world) => {
+  void dt;
+
+  for (const entityId of Array.from(trackedEntities)) {
+    if (!world.hasEntity(entityId)) {
+      trackedEntities.delete(entityId);
+    }
+  }
+
+  if (despawnAllRequested) {
+    for (const entityId of Array.from(trackedEntities)) {
+      world.destroyEntity(entityId);
+    }
+    trackedEntities.clear();
+    despawnAllRequested = false;
+  }
+
+  if (spawnQueue.length === 0) {
+    return;
+  }
+
+  const positionStore = world.getComponentStore<Position>(PositionKey);
+  if (!positionStore) {
+    spawnQueue.length = 0;
+    return;
+  }
+
+  const dotStore = world.getComponentStore<RenderDot>(RenderDotKey);
+  const labelStore = world.getComponentStore<RenderLabel>(RenderLabelKey);
+  const lifetimeStore = world.getComponentStore<Lifetime>(LifetimeKey);
+
+  while (spawnQueue.length > 0) {
+    const request = spawnQueue.shift()!;
+
+    if (request.kind === 'dot' && !dotStore) {
+      continue;
+    }
+
+    if (request.kind === 'label' && !labelStore) {
+      continue;
+    }
+
+    const entityId = world.createEntity();
+    trackedEntities.add(entityId);
+
+    positionStore.set(entityId, { x: request.x, y: request.y });
+
+    if (request.kind === 'dot') {
+      dotStore?.set(entityId, {
+        radius: request.radius ?? 1,
+        color: request.color,
+      });
+    } else {
+      labelStore?.set(entityId, {
+        text: request.text,
+        size: request.size,
+        color: request.color,
+      });
+    }
+
+    const lifetime = normalizeLifetime(request.ttl);
+    if (lifetime !== undefined && lifetimeStore) {
+      lifetimeStore.set(entityId, { ticksToLive: lifetime });
+    }
+  }
+}) as System;
+
+spawningSystem.displayName = 'Sim::Spawning';

--- a/src/test/game/systems/Spawning.test.ts
+++ b/src/test/game/systems/Spawning.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+
+import { World } from '@/core/ecs/World';
+import { PositionKey, type Position } from '@/core/ecs/components/Position';
+import { RenderDotKey, type RenderDot } from '@/core/ecs/components/RenderDot';
+import { RenderLabelKey, type RenderLabel } from '@/core/ecs/components/RenderLabel';
+import { LifetimeKey, type Lifetime } from '@/core/ecs/components/Lifetime';
+import { queueSpawn, spawningSystem } from '@/game/systems/Spawning';
+import { garbageCollectSystem } from '@/game/systems/GarbageCollect';
+
+describe('Spawning system', () => {
+  let world: World;
+
+  beforeEach(() => {
+    world = new World();
+    world.registerComponentStore(PositionKey);
+    world.registerComponentStore(RenderDotKey);
+    world.registerComponentStore(RenderLabelKey);
+    world.registerComponentStore(LifetimeKey);
+  });
+
+  it('creates entities with expected components from spawn requests', () => {
+    queueSpawn({ kind: 'dot', x: 10, y: 12, radius: 5, color: 0x123456, ttl: 3 });
+
+    spawningSystem(16, world);
+
+    const positionStore = world.getComponentStore<Position>(PositionKey)!;
+    const dotStore = world.getComponentStore<RenderDot>(RenderDotKey)!;
+    const lifetimeStore = world.getComponentStore<Lifetime>(LifetimeKey)!;
+
+    const entries = Array.from(positionStore.entries());
+    expect(entries).toHaveLength(1);
+
+    const [entityId, position] = entries[0];
+    expect(position).toEqual({ x: 10, y: 12 });
+    expect(dotStore.get(entityId)).toEqual({ radius: 5, color: 0x123456 });
+    expect(lifetimeStore.get(entityId)).toEqual({ ticksToLive: 3 });
+  });
+
+  it('removes entities after their lifetime expires', () => {
+    queueSpawn({ kind: 'label', x: 4, y: 6, text: 'hi', size: 10, color: 0xabcdef, ttl: 2 });
+
+    spawningSystem(16, world);
+    let positionStore = world.getComponentStore<Position>(PositionKey)!;
+    let labelStore = world.getComponentStore<RenderLabel>(RenderLabelKey)!;
+
+    const entries = Array.from(labelStore.entries());
+    expect(entries).toHaveLength(1);
+    const [entityId, label] = entries[0];
+    expect(label).toEqual({ text: 'hi', size: 10, color: 0xabcdef });
+    expect(positionStore.get(entityId)).toEqual({ x: 4, y: 6 });
+
+    // First tick after spawn - lifetime should decrement but entity remains.
+    spawningSystem(16, world);
+    garbageCollectSystem(16, world);
+    expect(world.entityCount).toBe(1);
+
+    // Second tick after spawn - entity should still exist (lifetime reaches zero).
+    spawningSystem(16, world);
+    garbageCollectSystem(16, world);
+    expect(world.entityCount).toBe(1);
+
+    // Third tick - lifetime expired, entity removed.
+    spawningSystem(16, world);
+    garbageCollectSystem(16, world);
+    expect(world.entityCount).toBe(0);
+
+    labelStore = world.getComponentStore<RenderLabel>(RenderLabelKey)!;
+    expect(labelStore.size()).toBe(0);
+  });
+});

--- a/src/ui/overlay/DevPanel.ts
+++ b/src/ui/overlay/DevPanel.ts
@@ -1,13 +1,25 @@
-import { profiling } from '@/core/services/Profiling';
 import { eventBus } from '@/core/services/EventBus';
+import { profiling } from '@/core/services/Profiling';
+import { GAME_HEIGHT, GAME_WIDTH, SCENES } from '@/core/config';
+import { queueDespawnAll, queueSpawn } from '@/game/systems/Spawning';
+import type Phaser from 'phaser';
 import type { ProfilingService } from '@/core/services/Profiling';
 import type { CoreEvents } from '@/core/types';
+
+type ButtonKey =
+  | 'pause'
+  | 'play'
+  | 'step'
+  | 'reset'
+  | 'spawnDot'
+  | 'spawnLabel'
+  | 'clearAll';
 
 export class DevPanel {
   private readonly container: HTMLDivElement;
   private readonly stats: HTMLDivElement;
   private readonly timings: HTMLUListElement;
-  private readonly buttons: Record<'pause' | 'play' | 'step' | 'reset', HTMLButtonElement>;
+  private readonly buttons: Record<ButtonKey, HTMLButtonElement>;
   private readonly unsubscribes: Array<() => void> = [];
   private visible = false;
   private paused = false;
@@ -26,19 +38,35 @@ export class DevPanel {
     this.timings = document.createElement('ul');
     this.timings.className = 'dev-panel__timings';
 
-    const controls = document.createElement('div');
-    controls.className = 'dev-panel__controls';
+    const simControls = document.createElement('div');
+    simControls.className = 'dev-panel__controls';
+
+    const spawnControls = document.createElement('div');
+    spawnControls.className = 'dev-panel__controls';
 
     this.buttons = {
       pause: this.createButton('Pause', () => this.emitCommand('pause')),
       play: this.createButton('Play', () => this.emitCommand('resume')),
       step: this.createButton('Step', () => this.emitCommand('step')),
       reset: this.createButton('Reset', () => this.emitCommand('reset')),
+      spawnDot: this.createButton('Spawn Dot', () => this.spawnDot()),
+      spawnLabel: this.createButton('Spawn Label', () => this.spawnLabel()),
+      clearAll: this.createButton('Clear All', () => this.clearAll()),
     };
 
-    controls.append(this.buttons.pause, this.buttons.play, this.buttons.step, this.buttons.reset);
+    simControls.append(
+      this.buttons.pause,
+      this.buttons.play,
+      this.buttons.step,
+      this.buttons.reset,
+    );
+    spawnControls.append(
+      this.buttons.spawnDot,
+      this.buttons.spawnLabel,
+      this.buttons.clearAll,
+    );
 
-    this.container.append(this.stats, controls, this.timings);
+    this.container.append(this.stats, simControls, spawnControls, this.timings);
     document.body.appendChild(this.container);
 
     this.unsubscribes.push(
@@ -76,6 +104,57 @@ export class DevPanel {
     this.buttons.pause.disabled = this.paused;
     this.buttons.play.disabled = !this.paused;
     this.buttons.step.disabled = !this.paused;
+  }
+
+  private spawnDot(): void {
+    const { x, y } = this.getSpawnCoordinates();
+    queueSpawn({ kind: 'dot', x, y, radius: 3, color: 0x00ff88 });
+  }
+
+  private spawnLabel(): void {
+    const { x, y } = this.getSpawnCoordinates();
+    queueSpawn({ kind: 'label', x, y, text: 'hello', size: 8, color: 0xffff00 });
+  }
+
+  private clearAll(): void {
+    queueDespawnAll();
+  }
+
+  private getSpawnCoordinates(): { x: number; y: number } {
+    const scene = this.getPlayScene();
+
+    if (scene) {
+      const pointer = scene.input?.activePointer;
+      const pointerX = pointer?.worldX;
+      const pointerY = pointer?.worldY;
+
+      if (Number.isFinite(pointerX) && Number.isFinite(pointerY)) {
+        return { x: Math.round(pointerX!), y: Math.round(pointerY!) };
+      }
+
+      const camera = scene.cameras?.main;
+      if (camera) {
+        const midPoint = camera.midPoint;
+        return { x: Math.round(midPoint.x), y: Math.round(midPoint.y) };
+      }
+    }
+
+    return { x: Math.round(GAME_WIDTH / 2), y: Math.round(GAME_HEIGHT / 2) };
+  }
+
+  private getPlayScene(): Phaser.Scene | undefined {
+    const game = window.terrariumGame;
+    if (!game) {
+      return undefined;
+    }
+
+    const sceneManager = game.scene;
+    if (!sceneManager.isActive?.(SCENES.PLAY)) {
+      return undefined;
+    }
+
+    const scene = sceneManager.getScene(SCENES.PLAY) as Phaser.Scene | undefined;
+    return scene ?? undefined;
   }
 
   private updateTimings(): void {


### PR DESCRIPTION
## Summary
- add ECS component keys for positions, renderable dots/labels, and lifetimes
- implement spawning, garbage collection, and Phaser rendering for demo dot and label entities
- hook dev panel buttons into the spawn queue and add tests covering spawn setup and lifetime expiry

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0262ff41c832b87a8ca11109b58ef